### PR TITLE
Add version for ledis command and make build will only build ledis

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This document explains how to contribute changes to the Ledisdb project.
 Please search the issues on the issue tracker with a variety of keywords
 to ensure your bug is not already reported.
 
-If unique, [open an issue](https://github.com/siddontang/ledisdb/issues/new)
+If unique, [open an issue](https://github.com/ledisdb/ledisdb/issues/new)
 and answer the questions so we can understand and reproduce the
 problematic behavior.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,16 @@ RUN apt-get update && \
     libgflags-dev
 
 # get LedisDB
-RUN wget -O ledisdb-src.tar.gz "https://github.com/siddontang/ledisdb/archive/v$LEDISDB_VERSION.tar.gz" && \
+RUN wget -O ledisdb-src.tar.gz "https://github.com/ledisdb/ledisdb/archive/v$LEDISDB_VERSION.tar.gz" && \
     tar -zxf ledisdb-src.tar.gz && \
-    mkdir -p /go/src/github.com/siddontang/ && \
-    mv ledisdb-$LEDISDB_VERSION /go/src/github.com/siddontang/ledisdb
+    mkdir -p /go/src/github.com/ledisdb/ && \
+    mv ledisdb-$LEDISDB_VERSION /go/src/github.com/ledisdb/ledisdb
 
 # build LevelDB
 RUN wget -O leveldb-src.tar.gz "https://github.com/google/leveldb/archive/$LEVELDB_VERSION.tar.gz" && \
     tar -zxf leveldb-src.tar.gz && \
     cd leveldb-$LEVELDB_VERSION && \
-    patch -p0 < /go/src/github.com/siddontang/ledisdb/tools/leveldb.patch && \
+    patch -p0 < /go/src/github.com/ledisdb/ledisdb/tools/leveldb.patch && \
     mkdir -p out-shared/db && \
     make -j "$(nproc)" && \
     mkdir /build/lib && \
@@ -59,7 +59,7 @@ RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/build/lib:/usr/lib && \
     export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/build/lib:/usr/lib && \
     mkdir -p /build/bin && \
     rm -rf /build/bin/* && \
-    cd /go/src/github.com/siddontang/ledisdb && \
+    cd /go/src/github.com/ledisdb/ledisdb && \
     GOGC=off go build -i -o /build/bin/ledis-server -tags "snappy leveldb rocksdb" cmd/ledis-server/* && \
     GOGC=off go build -i -o /build/bin/ledis-cli -tags "snappy leveldb rocksdb" cmd/ledis-cli/* && \
     GOGC=off go build -i -o /build/bin/ledis-benchmark -tags "snappy leveldb rocksdb" cmd/ledis-benchmark/* && \
@@ -84,7 +84,7 @@ FROM debian:stretch-slim
 
 COPY --from=builder /build/lib/* /usr/lib/
 COPY --from=builder /build/bin/ledis-* /bin/
-COPY --from=builder /go/src/github.com/siddontang/ledisdb/config/config-docker.toml /config.toml
+COPY --from=builder /go/src/github.com/ledisdb/ledisdb/config/config-docker.toml /config.toml
 COPY --from=builder /usr/local/bin/gosu /bin/
 
 RUN groupadd -r ledis && \

--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,15 @@ all: build
 build: build-ledis
 
 build-ledis:
-	go build -mod=vendor -tags '$(GO_BUILD_TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $(DIST)/ledis cmd/ledis/*.go
+	go build -mod=vendor -o $(DIST)/ledis -tags '$(GO_BUILD_TAGS)' -ldflags '-s -w $(LDFLAGS)' cmd/ledis/*.go
 
 build-commands:
-	go build -mod=vendor -o $(DIST)/ledis-server -tags '$(GO_BUILD_TAGS)' cmd/ledis-server/*.go
-	go build -mod=vendor -o $(DIST)/ledis-cli -tags '$(GO_BUILD_TAGS)' cmd/ledis-cli/*.go
-	go build -mod=vendor -o $(DIST)/ledis-benchmark -tags '$(GO_BUILD_TAGS)' cmd/ledis-benchmark/*.go
-	go build -mod=vendor -o $(DIST)/ledis-dump -tags '$(GO_BUILD_TAGS)' cmd/ledis-dump/*.go
-	go build -mod=vendor -o $(DIST)/ledis-load -tags '$(GO_BUILD_TAGS)' cmd/ledis-load/*.go
-	go build -mod=vendor -o $(DIST)/ledis-repair -tags '$(GO_BUILD_TAGS)' cmd/ledis-repair/*.go
+	go build -mod=vendor -o $(DIST)/ledis-server -tags '$(GO_BUILD_TAGS)' -ldflags '-s -w $(LDFLAGS)' cmd/ledis-server/*.go
+	go build -mod=vendor -o $(DIST)/ledis-cli -tags '$(GO_BUILD_TAGS)' -ldflags '-s -w $(LDFLAGS)' cmd/ledis-cli/*.go
+	go build -mod=vendor -o $(DIST)/ledis-benchmark -tags '$(GO_BUILD_TAGS)' -ldflags '-s -w $(LDFLAGS)' cmd/ledis-benchmark/*.go
+	go build -mod=vendor -o $(DIST)/ledis-dump -tags '$(GO_BUILD_TAGS)' -ldflags '-s -w $(LDFLAGS)' cmd/ledis-dump/*.go
+	go build -mod=vendor -o $(DIST)/ledis-load -tags '$(GO_BUILD_TAGS)' -ldflags '-s -w $(LDFLAGS)' cmd/ledis-load/*.go
+	go build -mod=vendor -o $(DIST)/ledis-repair -tags '$(GO_BUILD_TAGS)' -ldflags '-s -w $(LDFLAGS)' cmd/ledis-repair/*.go
 
 vet:
 	go vet -mod=vendor -tags '$(GO_BUILD_TAGS)' ./...

--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,25 @@ export DYLD_LIBRARY_PATH
 export GO_BUILD_TAGS
 export GO111MODULE=on
 
-
 PACKAGES ?= $(shell GO111MODULE=on go list -mod=vendor ./... | grep -v /vendor/)
+DIST := bin
+VERSION ?= $(shell git describe --tags --always | sed 's/-/+/' | sed 's/^v//')
+LDFLAGS := $(LDFLAGS) -X "main.version=$(VERSION)" -X "main.buildTags=$(GO_BUILD_TAGS)"
 
 all: build
 
-build:
-	go build -mod=vendor -o bin/ledis-server -tags '$(GO_BUILD_TAGS)' cmd/ledis-server/*.go
-	go build -mod=vendor -o bin/ledis-cli -tags '$(GO_BUILD_TAGS)' cmd/ledis-cli/*.go
-	go build -mod=vendor -o bin/ledis-benchmark -tags '$(GO_BUILD_TAGS)' cmd/ledis-benchmark/*.go
-	go build -mod=vendor -o bin/ledis-dump -tags '$(GO_BUILD_TAGS)' cmd/ledis-dump/*.go
-	go build -mod=vendor -o bin/ledis-load -tags '$(GO_BUILD_TAGS)' cmd/ledis-load/*.go
-	go build -mod=vendor -o bin/ledis-repair -tags '$(GO_BUILD_TAGS)' cmd/ledis-repair/*.go
+build: build-ledis
+
+build-ledis:
+	go build -mod=vendor -tags '$(GO_BUILD_TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $(DIST)/ledis cmd/ledis/*.go
+
+build-commands:
+	go build -mod=vendor -o $(DIST)/ledis-server -tags '$(GO_BUILD_TAGS)' cmd/ledis-server/*.go
+	go build -mod=vendor -o $(DIST)/ledis-cli -tags '$(GO_BUILD_TAGS)' cmd/ledis-cli/*.go
+	go build -mod=vendor -o $(DIST)/ledis-benchmark -tags '$(GO_BUILD_TAGS)' cmd/ledis-benchmark/*.go
+	go build -mod=vendor -o $(DIST)/ledis-dump -tags '$(GO_BUILD_TAGS)' cmd/ledis-dump/*.go
+	go build -mod=vendor -o $(DIST)/ledis-load -tags '$(GO_BUILD_TAGS)' cmd/ledis-load/*.go
+	go build -mod=vendor -o $(DIST)/ledis-repair -tags '$(GO_BUILD_TAGS)' cmd/ledis-repair/*.go
 
 vet:
 	go vet -mod=vendor -tags '$(GO_BUILD_TAGS)' ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LedisDB 
 
-[![Build Status](https://travis-ci.org/ledisdb/ledisdb.svg?branch=develop)](https://travis-ci.org/siddontang/ledisdb) [![codecov](https://codecov.io/gh/ledisdb/ledisdb/branch/master/graph/badge.svg)](https://codecov.io/gh/ledisdb/ledisdb)
+[![Build Status](https://travis-ci.org/ledisdb/ledisdb.svg?branch=develop)](https://travis-ci.org/ledisdb/ledisdb) [![codecov](https://codecov.io/gh/ledisdb/ledisdb/branch/master/graph/badge.svg)](https://codecov.io/gh/ledisdb/ledisdb)
 
 Ledisdb is a high-performance NoSQL database, similar to Redis, written in [Go](http://golang.org/). It supports many data structures including kv, list, hash, zset, set.
 
@@ -20,7 +20,7 @@ LedisDB now supports multiple different databases as backends.
 + HTTP API support, JSON/BSON/msgpack output.
 + Replication to guarantee data safety.
 + Supplies tools to load, dump, and repair database. 
-+ Supports cluster, use [xcodis](https://github.com/siddontang/xcodis)
++ Supports cluster, use [xcodis](https://github.com/ledisdb/xcodis)
 + Authentication (though, not via http)
 
 ## Build from source
@@ -145,7 +145,7 @@ Set slaveof in config or dynamiclly
 
 ## Cluster support
 
-LedisDB uses a proxy named [xcodis](https://github.com/siddontang/xcodis) to support cluster.
+LedisDB uses a proxy named [xcodis](https://github.com/ledisdb/xcodis) to support cluster.
 
 ## CONTRIBUTING
 

--- a/clear_vendor.sh
+++ b/clear_vendor.sh
@@ -1,6 +1,0 @@
-find vendor \( -type f -or -type l \)  -not -name "*.go" -not -name "LICENSE" -not -name "*.s" -not -name "PATENTS" -not -name "*.h" -not -name "*.c" | xargs -I {} rm {}
-# delete all test files
-find vendor -type f -name "*_generated.go" | xargs -I {} rm {}
-find vendor -type f -name "*_test.go" | xargs -I {} rm {}
-find vendor -type d -name "_vendor" | xargs -I {} rm -rf {}
-find vendor -type d -empty | xargs -I {} rm -rf {}

--- a/cmd/ledis-benchmark/main.go
+++ b/cmd/ledis-benchmark/main.go
@@ -1,7 +1,22 @@
 package main
 
-import "github.com/ledisdb/ledisdb/cmd"
+import (
+	"fmt"
+
+	"github.com/ledisdb/ledisdb/cmd"
+)
+
+var (
+	version  = "dev"
+	buildTag string
+)
 
 func main() {
+	fmt.Printf("Version %s", version)
+	if len(buildTag) > 0 {
+		fmt.Printf(" with tag %s", buildTag)
+	}
+	fmt.Println()
+
 	cmd.CmdBenchmark()
 }

--- a/cmd/ledis-cli/main.go
+++ b/cmd/ledis-cli/main.go
@@ -1,7 +1,22 @@
 package main
 
-import "github.com/ledisdb/ledisdb/cmd"
+import (
+	"fmt"
+
+	"github.com/ledisdb/ledisdb/cmd"
+)
+
+var (
+	version  = "dev"
+	buildTag string
+)
 
 func main() {
+	fmt.Printf("Version %s", version)
+	if len(buildTag) > 0 {
+		fmt.Printf(" with tag %s", buildTag)
+	}
+	fmt.Println()
+
 	cmd.CmdCli()
 }

--- a/cmd/ledis-dump/main.go
+++ b/cmd/ledis-dump/main.go
@@ -1,7 +1,22 @@
 package main
 
-import "github.com/ledisdb/ledisdb/cmd"
+import (
+	"fmt"
+
+	"github.com/ledisdb/ledisdb/cmd"
+)
+
+var (
+	version  = "dev"
+	buildTag string
+)
 
 func main() {
+	fmt.Printf("Version %s", version)
+	if len(buildTag) > 0 {
+		fmt.Printf(" with tag %s", buildTag)
+	}
+	fmt.Println()
+
 	cmd.CmdDump()
 }

--- a/cmd/ledis-load/main.go
+++ b/cmd/ledis-load/main.go
@@ -1,7 +1,22 @@
 package main
 
-import "github.com/ledisdb/ledisdb/cmd"
+import (
+	"fmt"
+
+	"github.com/ledisdb/ledisdb/cmd"
+)
+
+var (
+	version  = "dev"
+	buildTag string
+)
 
 func main() {
+	fmt.Printf("Version %s", version)
+	if len(buildTag) > 0 {
+		fmt.Printf(" with tag %s", buildTag)
+	}
+	fmt.Println()
+
 	cmd.CmdLoad()
 }

--- a/cmd/ledis-repair/main.go
+++ b/cmd/ledis-repair/main.go
@@ -1,7 +1,22 @@
 package main
 
-import "github.com/ledisdb/ledisdb/cmd"
+import (
+	"fmt"
+
+	"github.com/ledisdb/ledisdb/cmd"
+)
+
+var (
+	version  = "dev"
+	buildTag string
+)
 
 func main() {
+	fmt.Printf("Version %s", version)
+	if len(buildTag) > 0 {
+		fmt.Printf(" with tag %s", buildTag)
+	}
+	fmt.Println()
+
 	cmd.CmdRepair()
 }

--- a/cmd/ledis-server/main.go
+++ b/cmd/ledis-server/main.go
@@ -1,9 +1,22 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/ledisdb/ledisdb/cmd"
 )
 
+var (
+	version  = "dev"
+	buildTag string
+)
+
 func main() {
+	fmt.Printf("Version %s", version)
+	if len(buildTag) > 0 {
+		fmt.Printf(" with tag %s", buildTag)
+	}
+	fmt.Println()
+
 	cmd.CmdServer()
 }

--- a/cmd/ledis/main.go
+++ b/cmd/ledis/main.go
@@ -8,6 +8,9 @@ import (
 )
 
 var (
+	version  = "dev"
+	buildTag string
+
 	cmds = [][]string{
 		{"server", "run ledis server"},
 		{"cli", "run ledis client"},
@@ -29,6 +32,11 @@ func printCmd(cmd, description string) {
 }
 
 func main() {
+	fmt.Printf("Version %s", version)
+	if len(buildTag) > 0 {
+		fmt.Printf(" with tag %s", buildTag)
+	}
+	fmt.Println()
 	var subCmd string
 	if len(os.Args) == 1 {
 		subCmd = "server"

--- a/dev.sh
+++ b/dev.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 export LEDISTOP=$(pwd)
-export LEDISROOT="${LEDISROOT:-${LEDISTOP/\/src\/github.com\/siddontang\/ledisdb/}}"
+export LEDISROOT="${LEDISROOT:-${LEDISTOP/\/src\/github.com\/ledisdb\/ledisdb/}}"
 # LEDISTOP sanity check
-if [[ "$LEDISTOP" == "${LEDISTOP/\/src\/github.com\/siddontang\/ledisdb/}" ]]; then
-    echo "WARNING: LEDISTOP($LEDISTOP) does not contain src/github.com/siddontang/ledisdb"
+if [[ "$LEDISTOP" == "${LEDISTOP/\/src\/github.com\/ledisdb\/ledisdb/}" ]]; then
+    echo "WARNING: LEDISTOP($LEDISTOP) does not contain src/github.com/ledisdb/ledisdb"
     false
 fi
 

--- a/doc/DiffRedis.md
+++ b/doc/DiffRedis.md
@@ -48,4 +48,4 @@ XSCAN type cursor [MATCH match] [COUNT count]
 
 LedisDB supports `dump` to serialize the value with key, the data format is the same as Redis, so you can use it in Redis and vice versa. 
 
-Of course, LedisDB has not implemented all APIs in Redis, you can see full commands in commands.json, commands.doc or [wiki](https://github.com/siddontang/ledisdb/wiki/Commands).
+Of course, LedisDB has not implemented all APIs in Redis, you can see full commands in commands.json, commands.doc or [wiki](https://github.com/ledisdb/ledisdb/wiki/Commands).


### PR DESCRIPTION
When run `make build`, it will generate a version with the leids command. And when run ledis it now will display the version at first.